### PR TITLE
Add patches for (hopefully) better mod compatibility

### DIFF
--- a/Patches/VBECoffeesAndTeas.xml
+++ b/Patches/VBECoffeesAndTeas.xml
@@ -4,15 +4,19 @@
         <mods>
             <li>Vanilla Brewing Expanded - Coffees and Teas</li>
         </mods>
-        <match Class="PatchOperationAddModExtension">
-            <xpath>Defs/ThingDef[defName="VCE_RawLemon"]</xpath>
-            <value>
-                <li Class="NoMoreRiceWorld.ElementsDefModExtension">
-                    <Vitamines>0.5</Vitamines>
-                    <Carbohydrates>0.5</Carbohydrates>
-                    <Proteins>0</Proteins>
+        <match Class="PatchOperationSequence">
+            <operations>
+                <li Class="PatchOperationAddModExtension" MayRequire="VanillaExpanded.VPlantsE">
+                    <xpath>Defs/ThingDef[defName="VCE_RawLemon"]</xpath>
+                    <value>
+                        <li Class="NoMoreRiceWorld.ElementsDefModExtension">
+                            <Vitamines>0.5</Vitamines>
+                            <Carbohydrates>0.5</Carbohydrates>
+                            <Proteins>0</Proteins>
+                        </li>
+                    </value>
                 </li>
-            </value>
+            </operations>
         </match>
     </Operation>
 </Patch>

--- a/Patches/VBECoffeesAndTeas.xml
+++ b/Patches/VBECoffeesAndTeas.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+    <Operation Class="PatchOperationFindMod">
+        <mods>
+            <li>Vanilla Brewing Expanded - Coffees and Teas</li>
+        </mods>
+        <match Class="PatchOperationAddModExtension">
+            <xpath>Defs/ThingDef[defName="VCE_RawLemon"]</xpath>
+            <value>
+                <li Class="NoMoreRiceWorld.ElementsDefModExtension">
+                    <Vitamines>0.5</Vitamines>
+                    <Carbohydrates>0.5</Carbohydrates>
+                    <Proteins>0</Proteins>
+                </li>
+            </value>
+        </match>
+    </Operation>
+</Patch>

--- a/Patches/VCESushi.xml
+++ b/Patches/VCESushi.xml
@@ -12,7 +12,7 @@
                         <li Class="NoMoreRiceWorld.ElementsDefModExtension">
                             <Vitamines>0.5</Vitamines>
                             <Carbohydrates>0.7</Carbohydrates>
-                            <Proteins>0.7</Proteins>
+                            <Proteins>0</Proteins>
                         </li>
                     </value>
                 </li>

--- a/Patches/VCESushi.xml
+++ b/Patches/VCESushi.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+    <Operation Class="PatchOperationFindMod">
+        <mods>
+            <li>Vanilla Cooking Expanded - Sushi</li>
+        </mods>
+        <match Class="PatchOperationSequence">
+            <operations>
+                <li Class="PatchOperationAddModExtension">
+                    <xpath>Defs/ThingDef[defName="VCE_RawSoybean"]</xpath>
+                    <value>
+                        <li Class="NoMoreRiceWorld.ElementsDefModExtension">
+                            <Vitamines>0.5</Vitamines>
+                            <Carbohydrates>0.7</Carbohydrates>
+                            <Proteins>0.7</Proteins>
+                        </li>
+                    </value>
+                </li>
+                <li Class="PatchOperationAddModExtension">
+                    <xpath>Defs/ThingDef[defName="VCE_RawWasabi"]</xpath>
+                    <value>
+                        <li Class="NoMoreRiceWorld.ElementsDefModExtension">
+                            <Vitamines>0.5</Vitamines>
+                            <Carbohydrates>0.5</Carbohydrates>
+                            <Proteins>0</Proteins>
+                        </li>
+                    </value>
+                </li>
+            </operations>
+        </match>
+    </Operation>
+</Patch>

--- a/Patches/VFEMedieval.xml
+++ b/Patches/VFEMedieval.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+    <Operation Class="PatchOperationFindMod">
+        <mods>
+            <li>Vanilla Factions Expanded - Medieval</li>
+        </mods>
+        <match Class="PatchOperationAddModExtension">
+            <xpath>Defs/ThingDef[defName="VFEM_RawGrapes"]</xpath>
+            <value>
+                <li Class="NoMoreRiceWorld.ElementsDefModExtension">
+                    <Vitamines>0.5</Vitamines>
+                    <Carbohydrates>0.5</Carbohydrates>
+                    <Proteins>0</Proteins>
+                </li>
+            </value>
+        </match>
+    </Operation>
+</Patch>

--- a/Patches/VanillaPlantsExpanded.xml
+++ b/Patches/VanillaPlantsExpanded.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+    <Operation Class="PatchOperationFindMod">
+        <mods>
+            <li>Vanilla Plants Expanded</li>
+        </mods>
+        <match Class="PatchOperationSequence">
+            <operations>
+                <li Class="PatchOperationAddModExtension">
+                    <xpath>Defs/ThingDef[
+                        defName="VCE_RawApple" or
+                        defName="VCE_RawPeach" or
+                        defName="VCE_RawCherry" or
+                        defName="VCE_RawPlum" or
+                        defName="VCE_RawPear" or
+                        defName="VCE_RawPricklyPear" or
+                        defName="VCE_Bearberry" or
+                        defName="VCE_RawBanana" or
+                        defName="VCE_RawOrange" or
+                        defName="VCE_RawOnion" or
+                        defName="VCE_RawPumpkin" or
+                        defName="VCE_RawPepper" or
+                        defName="VCE_RawEggplant" or
+                        defName="VCE_RawCabbage" or
+                        defName="VCE_RawBeets" or
+                        defName="VCE_RawTomatoes"
+                    ]</xpath>
+                    <value>
+                        <li Class="NoMoreRiceWorld.ElementsDefModExtension">
+                            <Vitamines>0.5</Vitamines>
+                            <Carbohydrates>0.5</Carbohydrates>
+                            <Proteins>0</Proteins>
+                        </li>
+                    </value>
+                </li>
+                <li Class="PatchOperationAddModExtension">
+                    <xpath>Defs/ThingDef[defName="VCE_RawPeas"]</xpath>
+                    <value>
+                        <li Class="NoMoreRiceWorld.ElementsDefModExtension">
+                            <Vitamines>0.5</Vitamines>
+                            <Carbohydrates>0.5</Carbohydrates>
+                            <Proteins>0.3</Proteins>
+                        </li>
+                    </value>
+                </li>
+                <li Class="PatchOperationAddModExtension">
+                    <xpath>Defs/ThingDef[defName="VCE_RawPrunes"]</xpath>
+                    <value>
+                        <li Class="NoMoreRiceWorld.ElementsDefModExtension">
+                            <Vitamines>0.4</Vitamines>
+                            <Carbohydrates>0.4</Carbohydrates>
+                            <Proteins>0</Proteins>
+                        </li>
+                    </value>
+                </li>
+            </operations>
+        </match>
+    </Operation>
+</Patch>

--- a/Patches/VanillaPlantsExpanded.xml
+++ b/Patches/VanillaPlantsExpanded.xml
@@ -4,56 +4,34 @@
         <mods>
             <li>Vanilla Plants Expanded</li>
         </mods>
-        <match Class="PatchOperationSequence">
-            <operations>
-                <li Class="PatchOperationAddModExtension">
-                    <xpath>Defs/ThingDef[
-                        defName="VCE_RawApple" or
-                        defName="VCE_RawPeach" or
-                        defName="VCE_RawCherry" or
-                        defName="VCE_RawPlum" or
-                        defName="VCE_RawPear" or
-                        defName="VCE_RawPricklyPear" or
-                        defName="VCE_Bearberry" or
-                        defName="VCE_RawBanana" or
-                        defName="VCE_RawOrange" or
-                        defName="VCE_RawOnion" or
-                        defName="VCE_RawPumpkin" or
-                        defName="VCE_RawPepper" or
-                        defName="VCE_RawEggplant" or
-                        defName="VCE_RawCabbage" or
-                        defName="VCE_RawBeets" or
-                        defName="VCE_RawTomatoes"
-                    ]</xpath>
-                    <value>
-                        <li Class="NoMoreRiceWorld.ElementsDefModExtension">
-                            <Vitamines>0.5</Vitamines>
-                            <Carbohydrates>0.5</Carbohydrates>
-                            <Proteins>0</Proteins>
-                        </li>
-                    </value>
+        <match Class="PatchOperationAddModExtension">
+            <xpath>Defs/ThingDef[
+                defName="VCE_RawApple" or
+                defName="VCE_RawPeach" or
+                defName="VCE_RawCherry" or
+                defName="VCE_RawPlum" or
+                defName="VCE_RawPear" or
+                defName="VCE_RawPricklyPear" or
+                defName="VCE_Bearberry" or
+                defName="VCE_RawBanana" or
+                defName="VCE_RawOrange" or
+                defName="VCE_RawOnion" or
+                defName="VCE_RawPumpkin" or
+                defName="VCE_RawPepper" or
+                defName="VCE_RawEggplant" or
+                defName="VCE_RawCabbage" or
+                defName="VCE_RawBeets" or
+                defName="VCE_RawTomatoes" or
+                defName="VCE_RawPeas" or
+                defName="VCE_RawPrunes"
+            ]</xpath>
+            <value>
+                <li Class="NoMoreRiceWorld.ElementsDefModExtension">
+                    <Vitamines>0.5</Vitamines>
+                    <Carbohydrates>0.5</Carbohydrates>
+                    <Proteins>0</Proteins>
                 </li>
-                <li Class="PatchOperationAddModExtension">
-                    <xpath>Defs/ThingDef[defName="VCE_RawPeas"]</xpath>
-                    <value>
-                        <li Class="NoMoreRiceWorld.ElementsDefModExtension">
-                            <Vitamines>0.5</Vitamines>
-                            <Carbohydrates>0.5</Carbohydrates>
-                            <Proteins>0.3</Proteins>
-                        </li>
-                    </value>
-                </li>
-                <li Class="PatchOperationAddModExtension">
-                    <xpath>Defs/ThingDef[defName="VCE_RawPrunes"]</xpath>
-                    <value>
-                        <li Class="NoMoreRiceWorld.ElementsDefModExtension">
-                            <Vitamines>0.4</Vitamines>
-                            <Carbohydrates>0.4</Carbohydrates>
-                            <Proteins>0</Proteins>
-                        </li>
-                    </value>
-                </li>
-            </operations>
+            </value>
         </match>
     </Operation>
 </Patch>

--- a/Patches/VanillaPlantsExpandedMorePlants.xml
+++ b/Patches/VanillaPlantsExpandedMorePlants.xml
@@ -128,7 +128,7 @@
                         </li>
                     </value>
                 </li>
-                <li Class="PatchOperationAddModExtension">
+                <li Class="PatchOperationAddModExtension" MayRequire="VanillaExpanded.VCookE">
                     <xpath>Defs/ThingDef[defName="VCE_RawOats"]</xpath>
                     <value>
                         <li Class="NoMoreRiceWorld.ElementsDefModExtension">

--- a/Patches/VanillaPlantsExpandedMorePlants.xml
+++ b/Patches/VanillaPlantsExpandedMorePlants.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+    <Operation Class="PatchOperationFindMod">
+        <mods>
+            <li>Vanilla Plants Expanded - More Plants</li>
+        </mods>
+        <match Class="PatchOperationSequence">
+            <operations>
+                <li Class="PatchOperationAddModExtension">
+                    <xpath>Defs/ThingDef[
+                        defName="VCE_RawAvocado" or
+                        defName="VCE_RawMelon" or
+                        defName="VCE_RawCoconut" or
+                        defName="VCE_Mangoes" or
+                        defName="VCE_RawCelery" or
+                        defName="VCE_RawLettuce" or
+                        defName="VCE_RawRadish" or
+                        defName="VCE_RawOkra" or
+                        defName="VCE_RawGarlic" or
+                        defName="VCE_RawCarrot" or
+                        defName="VCE_RawBrusselsSprouts" or
+                        defName="VCE_RawOlives" or
+                        defName="VCE_RawCassava" or
+                        defName="VCE_RawBellPeppers" or
+                        defName="VCE_RawTaro" or
+                        defName="VCE_RawWatercress" or
+                        defName="VCE_RawLotus" or
+                        defName="VCE_RawWaterChestnut" or
+                        defName="VCE_RawCucumber" or
+                        defName="VCE_RawButternutSquash" or
+                        defName="VCE_RawBlueberries"
+                    ]</xpath>
+                    <value>
+                        <li Class="NoMoreRiceWorld.ElementsDefModExtension">
+                            <Vitamines>0.5</Vitamines>
+                            <Carbohydrates>0.5</Carbohydrates>
+                            <Proteins>0</Proteins>
+                        </li>
+                    </value>
+                </li>
+                <li Class="PatchOperationAddModExtension">
+                    <xpath>Defs/ThingDef[defName="VCE_RawSweetPotatoes"]</xpath>
+                    <value>
+                        <li Class="NoMoreRiceWorld.ElementsDefModExtension">
+                            <Vitamines>0.1</Vitamines>
+                            <Carbohydrates>0.9</Carbohydrates>
+                            <Proteins>0.05</Proteins>
+                        </li>
+                    </value>
+                </li>
+                <li Class="PatchOperationAddModExtension">
+                    <xpath>Defs/ThingDef[defName="VCE_RawSunflower"]</xpath>
+                    <value>
+                        <li Class="NoMoreRiceWorld.ElementsDefModExtension">
+                            <Vitamines>0.5</Vitamines>
+                            <Carbohydrates>0.5</Carbohydrates>
+                            <Proteins>0.34</Proteins>
+                        </li>
+                    </value>
+                </li>
+                <li Class="PatchOperationAddModExtension">
+                    <xpath>Defs/ThingDef[defName="VCE_RawAlmonds"]</xpath>
+                    <value>
+                        <li Class="NoMoreRiceWorld.ElementsDefModExtension">
+                            <Vitamines>0.5</Vitamines>
+                            <Carbohydrates>0.5</Carbohydrates>
+                            <Proteins>0.22</Proteins>
+                        </li>
+                    </value>
+                </li>
+                <li Class="PatchOperationAddModExtension">
+                    <xpath>Defs/ThingDef[defName="VCE_RawPeanut"]</xpath>
+                    <value>
+                        <li Class="NoMoreRiceWorld.ElementsDefModExtension">
+                            <Vitamines>0.5</Vitamines>
+                            <Carbohydrates>0.5</Carbohydrates>
+                            <Proteins>0.24</Proteins>
+                        </li>
+                    </value>
+                </li>
+                <li Class="PatchOperationAddModExtension">
+                    <xpath>Defs/ThingDef[defName="VCE_RawBuckwheat"]</xpath>
+                    <value>
+                        <li Class="NoMoreRiceWorld.ElementsDefModExtension">
+                            <Vitamines>0.5</Vitamines>
+                            <Carbohydrates>0.5</Carbohydrates>
+                            <Proteins>0.14</Proteins>
+                        </li>
+                    </value>
+                </li>
+                <li Class="PatchOperationAddModExtension">
+                    <xpath>Defs/ThingDef[defName="VCE_RawBeans"]</xpath>
+                    <value>
+                        <li Class="NoMoreRiceWorld.ElementsDefModExtension">
+                            <Vitamines>0.5</Vitamines>
+                            <Carbohydrates>0.5</Carbohydrates>
+                            <Proteins>0.28</Proteins>
+                        </li>
+                    </value>
+                </li>
+                <li Class="PatchOperationAddModExtension">
+                    <xpath>Defs/ThingDef[defName="VCE_RawPineapple"]</xpath>
+                    <value>
+                        <li Class="NoMoreRiceWorld.ElementsDefModExtension">
+                            <Vitamines>0.75</Vitamines>
+                            <Carbohydrates>0.75</Carbohydrates>
+                            <Proteins>0</Proteins>
+                        </li>
+                    </value>
+                </li>
+                <li Class="PatchOperationAddModExtension">
+                    <xpath>Defs/ThingDef[defName="VCE_RawYellowBellPeppers"]</xpath>
+                    <value>
+                        <li Class="NoMoreRiceWorld.ElementsDefModExtension">
+                            <Vitamines>0.6</Vitamines>
+                            <Carbohydrates>0.6</Carbohydrates>
+                            <Proteins>0</Proteins>
+                        </li>
+                    </value>
+                </li>
+                <li Class="PatchOperationAddModExtension">
+                    <xpath>Defs/ThingDef[defName="VCE_RawChickpeas"]</xpath>
+                    <value>
+                        <li Class="NoMoreRiceWorld.ElementsDefModExtension">
+                            <Vitamines>0.1</Vitamines>
+                            <Carbohydrates>0.84</Carbohydrates>
+                            <Proteins>0.28</Proteins>
+                        </li>
+                    </value>
+                </li>
+                <li Class="PatchOperationAddModExtension">
+                    <xpath>Defs/ThingDef[defName="VCE_RawOats"]</xpath>
+                    <value>
+                        <li Class="NoMoreRiceWorld.ElementsDefModExtension">
+                            <Vitamines>0.5</Vitamines>
+                            <Carbohydrates>0.5</Carbohydrates>
+                            <Proteins>0.1</Proteins>
+                        </li>
+                    </value>
+                </li>
+            </operations>
+        </match>
+    </Operation>
+</Patch>

--- a/Patches/VanillaPlantsExpandedMorePlants.xml
+++ b/Patches/VanillaPlantsExpandedMorePlants.xml
@@ -28,7 +28,14 @@
                         defName="VCE_RawWaterChestnut" or
                         defName="VCE_RawCucumber" or
                         defName="VCE_RawButternutSquash" or
-                        defName="VCE_RawBlueberries"
+                        defName="VCE_RawBlueberries" or
+                        defName="VCE_RawSunflower" or
+                        defName="VCE_RawAlmonds" or
+                        defName="VCE_RawPeanut" or
+                        defName="VCE_RawBuckwheat" or
+                        defName="VCE_RawBeans" or
+                        defName="VCE_RawPineapple" or
+                        defName="VCE_RawYellowBellPeppers"
                     ]</xpath>
                     <value>
                         <li Class="NoMoreRiceWorld.ElementsDefModExtension">
@@ -38,103 +45,23 @@
                         </li>
                     </value>
                 </li>
-                <li Class="PatchOperationAddModExtension">
-                    <xpath>Defs/ThingDef[defName="VCE_RawSweetPotatoes"]</xpath>
-                    <value>
-                        <li Class="NoMoreRiceWorld.ElementsDefModExtension">
-                            <Vitamines>0.1</Vitamines>
-                            <Carbohydrates>0.9</Carbohydrates>
-                            <Proteins>0.05</Proteins>
-                        </li>
-                    </value>
-                </li>
-                <li Class="PatchOperationAddModExtension">
-                    <xpath>Defs/ThingDef[defName="VCE_RawSunflower"]</xpath>
-                    <value>
-                        <li Class="NoMoreRiceWorld.ElementsDefModExtension">
-                            <Vitamines>0.5</Vitamines>
-                            <Carbohydrates>0.5</Carbohydrates>
-                            <Proteins>0.34</Proteins>
-                        </li>
-                    </value>
-                </li>
-                <li Class="PatchOperationAddModExtension">
-                    <xpath>Defs/ThingDef[defName="VCE_RawAlmonds"]</xpath>
-                    <value>
-                        <li Class="NoMoreRiceWorld.ElementsDefModExtension">
-                            <Vitamines>0.5</Vitamines>
-                            <Carbohydrates>0.5</Carbohydrates>
-                            <Proteins>0.22</Proteins>
-                        </li>
-                    </value>
-                </li>
-                <li Class="PatchOperationAddModExtension">
-                    <xpath>Defs/ThingDef[defName="VCE_RawPeanut"]</xpath>
-                    <value>
-                        <li Class="NoMoreRiceWorld.ElementsDefModExtension">
-                            <Vitamines>0.5</Vitamines>
-                            <Carbohydrates>0.5</Carbohydrates>
-                            <Proteins>0.24</Proteins>
-                        </li>
-                    </value>
-                </li>
-                <li Class="PatchOperationAddModExtension">
-                    <xpath>Defs/ThingDef[defName="VCE_RawBuckwheat"]</xpath>
-                    <value>
-                        <li Class="NoMoreRiceWorld.ElementsDefModExtension">
-                            <Vitamines>0.5</Vitamines>
-                            <Carbohydrates>0.5</Carbohydrates>
-                            <Proteins>0.14</Proteins>
-                        </li>
-                    </value>
-                </li>
-                <li Class="PatchOperationAddModExtension">
-                    <xpath>Defs/ThingDef[defName="VCE_RawBeans"]</xpath>
-                    <value>
-                        <li Class="NoMoreRiceWorld.ElementsDefModExtension">
-                            <Vitamines>0.5</Vitamines>
-                            <Carbohydrates>0.5</Carbohydrates>
-                            <Proteins>0.28</Proteins>
-                        </li>
-                    </value>
-                </li>
-                <li Class="PatchOperationAddModExtension">
-                    <xpath>Defs/ThingDef[defName="VCE_RawPineapple"]</xpath>
-                    <value>
-                        <li Class="NoMoreRiceWorld.ElementsDefModExtension">
-                            <Vitamines>0.75</Vitamines>
-                            <Carbohydrates>0.75</Carbohydrates>
-                            <Proteins>0</Proteins>
-                        </li>
-                    </value>
-                </li>
-                <li Class="PatchOperationAddModExtension">
-                    <xpath>Defs/ThingDef[defName="VCE_RawYellowBellPeppers"]</xpath>
-                    <value>
-                        <li Class="NoMoreRiceWorld.ElementsDefModExtension">
-                            <Vitamines>0.6</Vitamines>
-                            <Carbohydrates>0.6</Carbohydrates>
-                            <Proteins>0</Proteins>
-                        </li>
-                    </value>
-                </li>
-                <li Class="PatchOperationAddModExtension">
-                    <xpath>Defs/ThingDef[defName="VCE_RawChickpeas"]</xpath>
-                    <value>
-                        <li Class="NoMoreRiceWorld.ElementsDefModExtension">
-                            <Vitamines>0.1</Vitamines>
-                            <Carbohydrates>0.84</Carbohydrates>
-                            <Proteins>0.28</Proteins>
-                        </li>
-                    </value>
-                </li>
                 <li Class="PatchOperationAddModExtension" MayRequire="VanillaExpanded.VCookE">
                     <xpath>Defs/ThingDef[defName="VCE_RawOats"]</xpath>
                     <value>
                         <li Class="NoMoreRiceWorld.ElementsDefModExtension">
                             <Vitamines>0.5</Vitamines>
                             <Carbohydrates>0.5</Carbohydrates>
-                            <Proteins>0.1</Proteins>
+                            <Proteins>0</Proteins>
+                        </li>
+                    </value>
+                </li>
+                <li Class="PatchOperationAddModExtension">
+                    <xpath>Defs/ThingDef[defName="VCE_RawSweetPotatoes" or defName="VCE_RawChickpeas"]</xpath>
+                    <value>
+                        <li Class="NoMoreRiceWorld.ElementsDefModExtension">
+                            <Vitamines>0.07</Vitamines>
+                            <Carbohydrates>0.9</Carbohydrates>
+                            <Proteins>0</Proteins>
                         </li>
                     </value>
                 </li>


### PR DESCRIPTION
PR добавляет патчи для следующих модов:

- Vanilla Plants Expanded
- Vanilla Plants Expanded - More Plants
- Vanilla Brewing Expanded - Coffees and Teas
- Vanilla Cooking Expanded - Sushi
- Vanilla Factions Expanded - Medieval

Я проверил внутри игры, но не пропатчил:

- VFE Insectoids/Vikings/Classical
- Vanilla Genetics Expanded
- Alpha Mechs
- Vanilla Cooking Expanded
- Vanilla Cooking Expanded - Stews
- Vanilla Brewing Expanded

Потому, что стандартные унаследованные значения вроде бы работают с точки зрения баланса — насколько я смог проверить за день. Есть несколько моментов, которые я бы хотел отметить.

1. Балансировал все цифры либо относительно уже существующих в `NoMoreRiceWorld`, либо фишек модов, например, в `Vanilla Plants Expanded - More Plants` они решили, что ананасы растут долго, но более питательны, поэтому я подумал, что будет логично привязаться к тому, что они пытались добавить в игру. Скрещиваю пальцы, чтобы это было хоть сколько-нибудь сбалансированно, но должно быть всё равно лучше, чем только 100% углеводов по-умолчанию. То, что я сразу хотел поправить — добавить белки растениям, потому что иначе колония вегетарианцев будет в невыгодном положении, играя с этим модом. Я отдельно предложу PR для ванильных растений на случай, если такие изменения — это не то, что планировал автор.
2. Я не стал разбираться, как работает алкоголь, и есть ли в исходном коде что-то, что как-то на эту категорию влияет — уже устал к тому времени подбирать сбалансированные цифры для всего остального, но алкоголь даёт какое-то мизерное, 5%, кажется, повышение углеводов, что, на мой взгляд, и так сойдёт, особенно, на фоне других источников питательных веществ, поэтому этих патчей пока должно быть достаточно до первых жалоб. В `VFE - Medieval` ещё, например, бочкам, которые производят вино, не добавили гизмо для дебага, поэтому единственный способ посмотреть, как работает весь процесс — это ждать долгие внутриигровые дни. Я жду выхода пары модов и буду начинать новую партию в RimWorld, тогда посмотрю на это ещё раз в течение ближайших месяцев.
3. В `Alpha Mechs` есть робот `Pristine slurrypede`, который примерно раз в день производит `Dusgusting nutrient paste meal` из ничего (фактически энергии) — я не уверен, нужно ли это патчить каким-то образом, потому что ингридиентов он не использует, но при этом даёт по 25% всех питательных веществ. Наверное, здесь то же самое, что и с алкоголем, и поскольку ингридиентов у этой пасты нет, если что-то будет совсем несбалансированно, всегда можно добавить XML-патч конкретно для этого.
4. Мод `Alpha Animals` довольно популярен, но я никогда с ним не играл, и он добавляет очень много животных, поэтому сходу предположу, что для него тоже могут понадобиться какие-то патчи — просто для информации, если кто-то будет спрашивать. Я пока это трогать не хочу.

У меня нет твёрдого мнения на счёт цифр в этих патчах, возможно, я даже слишком сильно сфокусировался на том, чтобы найти какую-то общую точку между тем, что `NoMoreRiceWorld` делает, реальной жизнью и карикатурной симуляцией в игре, но, опять же, довольно тяжело сразу сбалансировать такое большое количество еды, поэтому, конечно же, приветствую какие-угодно изменения к этому предложению.